### PR TITLE
add shortcut for syphon command and fix short and long descroption

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -24,8 +24,11 @@ import (
 // addCmd represents the add command
 var addCmd = &cobra.Command{
 	Use:   "add alias \"command\" [category]",
-	Short: "add shell command to database.",
-	Long:  "add shell command to database You can include category by specifying it on command, see syphon add --help to see add command help.",
+	Short: "add shell command.",
+	Long:  "add shell command to database.",
+	Aliases: []string{"a"},
+	Example: `  - syphon add "ls -la" utility
+  - syphon add "ls -la"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		addShellCommand(args)
 	},

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -25,9 +25,12 @@ import (
 
 // deleteCmd represents the delete command
 var deleteCmd = &cobra.Command{
-	Use:   "delete id [--alias alias] [-a alias]",
-	Short: "delete shell command from database",
-	Long:  "delete shell command from database, this command can use ID or alias for identifier check syphon delete --help to see delete command help",
+	Use:   "delete <command_id>",
+	Short: "delete saved shell command.",
+	Long:  "delete saved shell command from database by command id or command alias.",
+	Aliases: []string{"d", "remove"},
+	Example: `  - syphon delete 12
+  - syphon delete ssh-server-1`,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		byAlias, _ := cmd.Flags().GetBool("alias")

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -25,12 +25,12 @@ import (
 
 // deleteCmd represents the delete command
 var deleteCmd = &cobra.Command{
-	Use:   "delete <command_id>",
+	Use:   "delete [<command_id>] [--alias <alias>]",
 	Short: "delete saved shell command.",
 	Long:  "delete saved shell command from database by command id or command alias.",
 	Aliases: []string{"d", "remove"},
 	Example: `  - syphon delete 12
-  - syphon delete ssh-server-1`,
+  - syphon delete --alias ssh-server-1`,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		byAlias, _ := cmd.Flags().GetBool("alias")

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -23,9 +23,12 @@ import (
 
 // execCmd represents the add command
 var execCmd = &cobra.Command{
-	Use:   "exec alias",
-	Short: "exec shell command from database.",
-	Long:  "exec shell command from database, see syphon add --help to see add command help.",
+	Use:   "exec <alias>",
+	Short: "execute saved shell command.",
+	Long:  "execute saved shell command from database by shell command alias or id.",
+	Aliases: []string{"e"},
+	Example: `  - syphon exec ssh-server-1
+  - syphon e ssh-server-1`,
 	Run: func(cmd *cobra.Command, args []string) {
 		execShellCommand(args)
 	},

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -24,8 +24,10 @@ import (
 // listCmd represents the list command
 var listCmd = &cobra.Command{
 	Use:   "list",
-	Short: "list your command from database",
-	Long:  "list shell command from database.",
+	Short: "list saved shell command.",
+	Long:  "list saved shell command from database.",
+	Aliases: []string{"l"},
+	Example: "  - syphon list \n  - syphon l",
 	Run: func(cmd *cobra.Command, args []string) {
 		listShellCommand()
 	},

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -27,7 +27,8 @@ var listCmd = &cobra.Command{
 	Short: "list saved shell command.",
 	Long:  "list saved shell command from database.",
 	Aliases: []string{"l"},
-	Example: "  - syphon list \n  - syphon l",
+	Example: `  - syphon list
+  - syphon l`,
 	Run: func(cmd *cobra.Command, args []string) {
 		listShellCommand()
 	},

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -24,8 +24,11 @@ import (
 // updateCmd represents the update command
 var updateCmd = &cobra.Command{
 	Use:   "update id [--alias alias] \"new_command\"",
-	Short: "update shell command from database.",
-	Long:  "update shell command from database, see syphon update --help to see update command help.",
+	Short: "update/edit shell command.",
+	Long:  "update/edit shell command from database by shell command alias or id.",
+	Aliases: []string{"u", "edit"},
+	Example: `  - syphon update 12 "ls -la"
+  - syphon update --alias super-ls "ls -la"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("update called")
 	},


### PR DESCRIPTION
## Add Alias for Command

- `syphon add` -> `syphon a`
- `syphon list` -> `syphon l`
- `syphon exec` -> `syphhon e`
- `syphon update` -> `syphon u`
- `syphon delete` -> `syphon delete`

cek `syphon <command> --help` for more info